### PR TITLE
Modifications for gcc 13, nvcc 12.3, and msgpack 5.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-CXX = g++
-NVCC = nvcc
+CXX = /usr/bin/g++
+NVCC = /usr/local/bin/nvcc
 CFLAGS = -O2
 LDFLAGS =
 LDLIBS = -lcuda -lcublas -lboost_regex -lboost_iostreams -lboost_program_options -lmsgpackc

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXX = /usr/bin/g++
-NVCC = /usr/local/bin/nvcc
+NVCC = /usr/local/cuda/bin/nvcc
 CFLAGS = -O2
 LDFLAGS =
 LDLIBS = -lcuda -lcublas -lboost_regex -lboost_iostreams -lboost_program_options -lmsgpackc

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-CXX = /usr/bin/g++
-NVCC = /usr/local/cuda/bin/nvcc
+CXX = g++
+NVCC = nvcc
 CFLAGS = -O2
 LDFLAGS =
-LDLIBS = -lcuda -lcublas -lboost_regex -lboost_iostreams -lboost_program_options -lmsgpack
+LDLIBS = -lcuda -lcublas -lboost_regex -lboost_iostreams -lboost_program_options -lmsgpackc
 BUILD_DIR = build
 PREFIX = /usr/local
 

--- a/Makefile.cuda12gcc13
+++ b/Makefile.cuda12gcc13
@@ -1,0 +1,46 @@
+CXX = /usr/bin/g++
+NVCC = nvcc
+CFLAGS = -O2
+CUDAFLAGS = -ccbin=/opt/cuda/bin
+LDFLAGS =
+LDLIBS = -lcuda -lcublas -lboost_regex -lboost_iostreams -lboost_program_options -lmsgpackc
+BUILD_DIR = build
+PREFIX = /usr/local
+
+HANDLERS = file_handler csv_handler mp_handler
+KERNELS = knn_cuda
+HANDLER_OBJS = $(HANDLERS:%=$(BUILD_DIR)/%.o)
+KERNEL_OBJS = $(KERNELS:%=$(BUILD_DIR)/%.o)
+OBJS = $(HANDLER_OBJS) $(KERNEL_OBJS) $(BUILD_DIR)/knn_finder.o
+HEADERS = $(HANDLERS:%=%.hpp) $(KERNELS:%=%.hpp)
+
+.PHONY: all install clean
+
+all: $(BUILD_DIR)/knn_finder
+
+install:
+	mkdir -p $(PREFIX)/bin
+	cp $(BUILD_DIR)/knn_finder $(PREFIX)/bin
+
+clean:
+	rm -f $(BUILD_DIR)/knn_finder
+	rm -f $(BUILD_DIR)/*.o
+
+$(BUILD_DIR)/knn_finder: $(OBJS)
+	$(NVCC) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+
+$(HANDLER_OBJS): $(BUILD_DIR)/%.o: %.cpp %.hpp
+	$(CXX) $(CFLAGS) -c -o $@ $<
+
+$(BUILD_DIR)/csv_handler.o $(BUILD_DIR)/mp_handler.o: file_handler.hpp
+
+$(KERNEL_OBJS): $(BUILD_DIR)/%.o: %.cu %.hpp
+	$(NVCC) $(CFLAGS) $(CUDAFLAGS) -c -o $@ $<
+
+$(BUILD_DIR)/knn_finder.o: knn_finder.cpp $(HEADERS)
+	$(NVCC) $(CFLAGS) $(CUDAFLAGS) -c -o $@ $<
+
+$(OBJS): | $(BUILD_DIR)
+
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)

--- a/README.md
+++ b/README.md
@@ -2,3 +2,13 @@ knn_finder
 ==========
 
 a brute force k-nearest neighbour search program for nVidia GPUs
+
+
+## Requirements and tested versions
+- gcc, tested with 13.2.1
+- cuda, tested with 12.3.0
+- boost, tested with 1.83.0
+- msgpack >= 2.0.0, tested with 5.0.0
+
+### Note
+If you are using the above versions, use Makefile.cuda12gcc13 instead of Makefile to make nvcc use an appropriate version of gcc.

--- a/csv_handler.cpp
+++ b/csv_handler.cpp
@@ -14,7 +14,11 @@ bool is_numeric(const std::string& str) {
 
 int read_csv(const char *filename, bool is_gzip, float **mat_ptr, int *nr_ptr, int *nc_ptr) {
 	file_reader reader(is_gzip);
-	if (!reader.open(filename, is_gzip)) return FILE_OPEN_FAILED;
+	try{
+		reader.open(filename, is_gzip);
+	}catch(const std::exception& e){
+		return FILE_OPEN_FAILED;
+	}
 	std::istream& is = reader.get();
 
 	int nr = 0, nc = 0;

--- a/file_handler.cpp
+++ b/file_handler.cpp
@@ -9,11 +9,10 @@ file_reader::file_reader(bool is_gzip) : ifs(), decomp(), sbuf(), is(&sbuf) {
 	sbuf.push(ifs);
 }
 
-bool file_reader::open(const char *filename, bool is_binary) {
+void file_reader::open(const char *filename, bool is_binary) {
 	std::ios_base::openmode mode = std::ios_base::in;
 	if (is_binary) mode |= std::ios_base::binary;
 	ifs.open(filename, mode);
-	return ifs;
 }
 
 std::istream& file_reader::get() {

--- a/file_handler.hpp
+++ b/file_handler.hpp
@@ -19,7 +19,7 @@ class file_reader {
 public:
 	file_reader(bool is_gzip=false);
 
-	bool open(const char *filename, bool is_binary=false);
+	void open(const char *filename, bool is_binary=false);
 	std::istream& get();
 
 private:

--- a/mp_handler.cpp
+++ b/mp_handler.cpp
@@ -11,7 +11,12 @@ int read_mp(const char *filename, bool is_gzip, float **mat_ptr, int *nr_ptr, in
 	std::vector<item_record> records;
 	{ // Block to destruct the file read buffer after copied the content to the records.
 		file_reader reader(is_gzip);
-		if (!reader.open(filename, true)) return FILE_OPEN_FAILED;
+		try{
+			reader.open(filename, true);
+		}
+		catch (const std::exception& e){
+			return FILE_OPEN_FAILED;
+		}
 		std::istream& is = reader.get();
 
 		// Seemingly unnecessary parentheses surrounding the 1st parameter is to stop
@@ -22,11 +27,11 @@ int read_mp(const char *filename, bool is_gzip, float **mat_ptr, int *nr_ptr, in
 
 		std::size_t offset = 0;
 		while (offset < buf.size()) {
-			msgpack::unpacked msg;
-			msgpack::unpack(&msg, &buf[0], buf.size(), &offset);
+			msgpack::object_handle msg;
+			msgpack::unpack(msg, &buf[0], buf.size(), offset);
 			msgpack::object obj(msg.get());
 			item_record record;
-			obj.convert(&record);
+			obj.convert(record);
 			records.push_back(record);
 		}
 	}


### PR DESCRIPTION
The current source code is incompatible with gcc 13 and msgpack >= 2.0.0, which causes compilation errors. I have updated the source code to fix these errors and ensure compatibility with the latest versions of gcc and msgpack.
